### PR TITLE
Harvest

### DIFF
--- a/n_body_plug/1body.py
+++ b/n_body_plug/1body.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+import shutil
+import shelve
+import os
+import subprocess
+
+## Submission script
+#  This script easily allows you to submit subsets of the n_body jobs broken
+#  down over approximation levels
+#  Jobs are submitted in reverse order by default because we're assuming the 
+#  solute(s) were the first fragments
+
+## List of jobs to be submitted
+#  Starts out empty
+body_list = []
+method_list = []
+
+# one-body
+body_list += [1]
+# two-body
+#body_list += [2]
+# three-body
+#body_list += [3]
+# four-body
+#body_list += [4]
+# five-body
+#body_list += [5]
+# six-body
+#body_list += [6]
+# seven-body
+#body_list += [7]
+# eight-body
+#body_list += [8]
+# nine-body
+#body_list += [9]
+# ten-body
+#body_list += [10]
+# eleven-body
+#body_list += [11]
+
+#method_list += ['b3lyp']
+#method_list += ['ccsd']
+method_list += ['cc2']
+
+## Submit file for jobs containing the solute molecule
+#  Default name is solute
+solute = 'solute'
+## Submit file for jobs containing only solvent molecules
+#  Default name is solvent
+solvent = 'solvent'
+
+## Solute fragments
+#  Default is fragment 1
+#  Everything else is assumed to be solvent
+solute_frags = set([1])
+
+def n_body_dir(n):
+    num_2_word = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven',
+                  'eight', 'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen']
+
+    return('{}_body'.format(num_2_word[n]))
+
+
+for method in method_list:
+    for n in body_list:
+        db = shelve.open('database')
+        job_list = db[method][n]['job_status']
+#       Example: db['cc2'][2]['job_status'] = OrderedDict([('1','not_started'),('2','not_started')])
+        body = n_body_dir(n)
+#       Example: n_body_dir(2) = 'two_body'
+        while job_list:
+            job,val = job_list.popitem(last=True)
+#           Example: job = 2 and val = not_started
+#           Actually pops the entry out of the job_list so that {while job_list:} actually ends
+            if val == 'not_started': # For now, only start not_started jobs. Start dead jobs later
+                print(job)
+                print('{}/{}/{}'.format(method,body,job))
+                os.chdir('{}/{}/{}'.format(method,body,job))
+#               Example: os.chdir('{}/{}/{}'.format('cc2','two_body',2)
+                subprocess.call(['psi4', 'input.dat', 'output.dat'])
+                os.chdir('../../..')
+        db.close()
+

--- a/n_body_plug/input.dat
+++ b/n_body_plug/input.dat
@@ -46,8 +46,18 @@ set n_body {
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 1})
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 3})
 
-# current running example of property calculation
-n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['quadrupole'])
+# current running examples of property calculations
+#n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['quadrupole'])
+set {
+    omega [355, 436, nm]
+}
+n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['polarizability'])
+#set {
+#   gauge both 
+#   omega [355, 436, nm]
+#   freeze_core true
+#}
+#n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['rotation'])
 
 # current running example for vmfc bsse calculations
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'vmfc'})

--- a/n_body_plug/input.dat
+++ b/n_body_plug/input.dat
@@ -46,6 +46,9 @@ set n_body {
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 1})
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 3})
 
+# current running example of property calculation
+n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['quadrupole'])
+
 # current running example for vmfc bsse calculations
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'vmfc'})
 
@@ -53,7 +56,7 @@ set n_body {
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'mbcp'})
 
 # current running example for ssfc bsse calculations
-n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'ssfc'})
+#n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'ssfc'})
 
 
 # generated input files should also have the following

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -47,7 +47,7 @@ import collections
 import psi4
 #import molutil
 #import proc
-#import sys
+import sys
 import copy
 #import functional
 #import driver
@@ -58,6 +58,8 @@ import copy
 import os
 #import p4util
 #import re
+# need json for new output structure
+import json
 
 def clean_up(db):
     try:
@@ -1111,12 +1113,16 @@ def harvest_g09(db,method,n):
 def harvest_scf_energy_data(db,method,n):
     body = n_body_dir(n)
     for job in db[method][n]['job_status']:
-        with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
-            for line in outfile:
-                if '@RHF Final Energy:' in line:
-                    (i,j,k, energy) = line.split()
-                    db[method][n]['scf_energy']['raw_data'].update({job: 
-                                                                [float(energy)]})
+#        with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
+#            for line in outfile:
+#                if '@RHF Final Energy:' in line:
+#                    (i,j,k, energy) = line.split()
+#                    db[method][n]['scf_energy']['raw_data'].update({job: 
+#                                                                [float(energy)]})
+        with open('{}/{}/{}/output.json'.format(method,body,job),'r') as outfile:
+            jout = json.load(outfile)
+            energy = jout["SCF TOTAL ENERGY"]
+            db[method][n]['scf_energy']['raw_data'].update({job:energy})
 
 def harvest_cc_energy(db,method,n):
     body = n_body_dir(n)

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -1153,19 +1153,25 @@ def harvest_scf_dipole_data(db,method,n):
     # the first time.
     body = n_body_dir(n)
     for job in db[method][n]['job_status']:
-        get_next = False
-        data_collected = False
-        with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
-            for line in outfile:
-                if get_next and not data_collected:
-                    # total dipole moment is discarded as n-body using magnitudes is meaningless
-                    (x,x_val,y,y_val,z,z_val,total,total_val) = line.split()
-                    db[method][n]['scf_dipole']['raw_data'].update({job: 
-                                    [float(x_val),float(y_val),float(z_val)]})
-                    get_next = False
-                    data_collected = True
-                if '  Dipole Moment: (Debye)' in line:
-                    get_next = True
+#        get_next = False
+#        data_collected = False
+#        with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
+#            for line in outfile:
+#                if get_next and not data_collected:
+#                    # total dipole moment is discarded as n-body using magnitudes is meaningless
+#                    (x,x_val,y,y_val,z,z_val,total,total_val) = line.split()
+#                    db[method][n]['scf_dipole']['raw_data'].update({job: 
+#                                    [float(x_val),float(y_val),float(z_val)]})
+#                    get_next = False
+#                    data_collected = True
+#                if '  Dipole Moment: (Debye)' in line:
+#                    get_next = True
+        with open('{}/{}/{}/output.json'.format(method,body,job),'r') as outfile:
+            jout = json.load(outfile)
+            x = jout["SCF DIPOLE X"]
+            y = jout["SCF DIPOLE Y"]
+            z = jout["SCF DIPOLE Z"]
+            db[method][n]['scf_dipole']['raw_data'].update({job:[x,y,z]})
 
 def harvest_g09_scf_dipole(db,method,n):
     body = n_body_dir(n)

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -1125,6 +1125,7 @@ def harvest_scf_energy_data(db,method,n):
             db[method][n]['scf_energy']['raw_data'].update({job:energy})
 
 def harvest_cc_energy(db,method,n):
+#####NOTE: is this function even useful??? find where this is used!!#####
     body = n_body_dir(n)
     name = psi4.get_global_option('WFN')
     for job in db[method][n]['job_status']:
@@ -1473,18 +1474,26 @@ def harvest_g09_polarizability_tensor(db, method, n):
 
 def harvest_cc_energy_data(db, method, n):
     body = n_body_dir(n)
-    cc_methods = ['cc2', 'ccsd', 'cc3', 'eom-cc2', 'eom-ccsd']
-    if method in cc_methods:
-        for job in db[method][n]['job_status']:
-            with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
-                for line in outfile:
-                    if '{} correlation energy'.format(method.upper()) in line:
-                        try:
-                            (i,j,k,l, energy) = line.split()
-                            db[method][n]['cc_energy']['raw_data'].update({job:
-                                                                 [float(energy)]})
-                        except:
-                            pass
+    name = method.upper()
+    print("Getting cc_energy from method:")
+    print(name)
+#    cc_methods = ['cc2', 'ccsd', 'cc3', 'eom-cc2', 'eom-ccsd']
+#    if method in cc_methods:
+    for job in db[method][n]['job_status']:
+#            with open('{}/{}/{}/output.dat'.format(method,body,job),'r') as outfile:
+#                for line in outfile:
+#                    if '{} correlation energy'.format(method.upper()) in line:
+#                        try:
+#                            (i,j,k,l, energy) = line.split()
+#                            db[method][n]['cc_energy']['raw_data'].update({job:
+#                                                                 [float(energy)]})
+#                        except:
+#                            pass
+        with open('{}/{}/{}/output.json'.format(method,body,job),'r') as outfile:
+            jout = json.load(outfile)
+            energy = jout["{} TOTAL ENERGY".format(name)]
+            db[method][n]['cc_energy']['raw_data'].update({job:energy})
+            print(db[method][n]['cc_energy']['raw_data'][job])
 
 def cook_data(db, method, n):
     # Automatic cooking requires all result data be stored as lists in the

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -354,7 +354,7 @@ def run_n_body(name, **kwargs):
     if not db['results_computed']:
         for method in db['methods'].keys():
             for field in db[method]['farm']:
-                print(field)
+                print("field: {}".format(field))
                 num_fin = db[method][field]['num_jobs_complete']
                 tot_num = db[method][field]['total_num_jobs']
                 print('{}/{} finished'.format(num_fin,tot_num))

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -350,11 +350,9 @@ def run_n_body(name, **kwargs):
     db = shelve.open('database',writeback=True)
 
     # Gather results
-    #### NOTE: testing data harvesting, DO NOT TRUST!!!####
     if not db['results_computed']:
         for method in db['methods'].keys():
             for field in db[method]['farm']:
-                print("field: {}".format(field))
                 num_fin = db[method][field]['num_jobs_complete']
                 tot_num = db[method][field]['total_num_jobs']
                 print('{}/{} finished'.format(num_fin,tot_num))

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -349,20 +349,20 @@ def run_n_body(name, **kwargs):
     db.close()
     db = shelve.open('database',writeback=True)
 
-#    # Gather results
-#    #### NOTE: skipping results gathering for now, working on input generation####
-#    if not db['results_computed']:
-#        for method in db['methods'].keys():
-#            for field in db[method]['farm']:
-#                print(field)
-#                num_fin = db[method][field]['num_jobs_complete']
-#                tot_num = db[method][field]['total_num_jobs']
-#                print('{}/{} finished'.format(num_fin,tot_num))
-#                if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
+    # Gather results
+    #### NOTE: testing data harvesting, DO NOT TRUST!!!####
+    if not db['results_computed']:
+        for method in db['methods'].keys():
+            for field in db[method]['farm']:
+                print(field)
+                num_fin = db[method][field]['num_jobs_complete']
+                tot_num = db[method][field]['total_num_jobs']
+                print('{}/{} finished'.format(num_fin,tot_num))
+                if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
 #                    if method in n_body.dft_methods:
 #                        n_body.harvest_g09(db,method,field)
 #                    else:
-#                        n_body.harvest_data(db,method,field)
+                    n_body.harvest_data(db,method,field)
 #            for field in db[method]['farm']:
 #                if isinstance(field, int):
 #                    n_body.cook_data(db,method,field)


### PR DESCRIPTION
The following `harvest` functions are working properly by pulling from `output.json`, which is populated by `psi4.core.get_variables()`. The `raw_data` is currently stored in the `database` shelf. 

- `harvest_data()`
- `harvest_scf_energy_data()`
- `harvest_scf_dipole_data()`
- `harvest_quadrupole_data()`
- `harvest_quadrupole_data()`
- `harvest_rotation_data()`
- `harvest_polarizability_data()`

Note that all of these functions are for wavefunction-based psi4 calculations (e.g. cc2, CCSD, etc).