### PR TITLE
Molecular weights, reap G09 energies, dipoles, quadrupoles, rotation tensors, rotations, molecular weights

### DIFF
--- a/n_body_plug/g09_1_2_3body.py
+++ b/n_body_plug/g09_1_2_3body.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import shutil
+import shelve
+import os
+import subprocess
+
+## Submission script
+#  This script easily allows you to submit subsets of the n_body jobs broken
+#  down over approximation levels
+#  Jobs are submitted in reverse order by default because we're assuming the 
+#  solute(s) were the first fragments
+
+## List of jobs to be submitted
+#  Starts out empty
+body_list = []
+method_list = []
+
+# one-body
+body_list += [1]
+# two-body
+body_list += [2]
+# three-body
+body_list += [3]
+# four-body
+#body_list += [4]
+# five-body
+#body_list += [5]
+# six-body
+#body_list += [6]
+# seven-body
+#body_list += [7]
+# eight-body
+#body_list += [8]
+# nine-body
+#body_list += [9]
+# ten-body
+#body_list += [10]
+# eleven-body
+#body_list += [11]
+
+method_list += ['b3lyp']
+#method_list += ['ccsd']
+#method_list += ['cc2']
+
+## Submit file for jobs containing the solute molecule
+#  Default name is solute
+solute = 'solute'
+## Submit file for jobs containing only solvent molecules
+#  Default name is solvent
+solvent = 'solvent'
+
+## Solute fragments
+#  Default is fragment 1
+#  Everything else is assumed to be solvent
+solute_frags = set([1])
+
+def n_body_dir(n):
+    num_2_word = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven',
+                  'eight', 'nine', 'ten', 'eleven', 'twelve', 'thirteen', 'fourteen']
+
+    return('{}_body'.format(num_2_word[n]))
+
+
+for method in method_list:
+    for n in body_list:
+        db = shelve.open('database')
+        job_list = db[method][n]['job_status']
+#       Example: db['cc2'][2]['job_status'] = OrderedDict([('1','not_started'),('2','not_started')])
+        body = n_body_dir(n)
+#       Example: n_body_dir(2) = 'two_body'
+        while job_list:
+            job,val = job_list.popitem(last=True)
+#           Example: job = 2 and val = not_started
+#           Actually pops the entry out of the job_list so that while job_list actually ends
+#            if val == 'not_started': # For now, only start not_started jobs. Start dead jobs later
+            if (val == 'not_started') or (val == 'error'):
+                print(job)
+                print('{}/{}/{}'.format(method,body,job))
+                os.chdir('{}/{}/{}'.format(method,body,job))
+#               Example: os.chdir('{}/{}/{}'.format('cc2','two_body',2)
+                subprocess.call(['g09', 'input.com', 'input.log'])
+                os.chdir('../../..')
+        db.close()
+

--- a/n_body_plug/input.dat
+++ b/n_body_plug/input.dat
@@ -27,9 +27,9 @@ set {
   basis sto-3g
 }
 
-set n_body {
-  print 1
-}
+#set n_body {
+#  print 1
+#}
 
 set {
    gauge velocity 
@@ -51,12 +51,12 @@ set {
 
 # current running example of energy calculation
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 1})
-#n_body_plug.run_n_body('cc2', n_body={'cc2': 3})
+#n_body_plug.run_n_body('b3lyp', n_body={'b3lyp': 3})
 
 # current running examples of property calculations
 #n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['quadrupole'])
 #n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['polarizability'])
-#n_body_plug.run_n_body('cc2', n_body={'cc2':1}, properties=['rotation'])
+#n_body_plug.run_n_body('b3lyp', n_body={'b3lyp':3}, properties=['rotation'])
 
 # current running example for vmfc bsse calculations
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'vmfc'})
@@ -67,7 +67,7 @@ set {
 # current running example for ssfc bsse calculations
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'ssfc'}, properties=['quadrupole'])
 # gaussian integration is currently being fixed
-n_body_plug.run_n_body('b3lyp', n_body={'b3lyp': 2, 'bsse': 'ssfc'}, properties=['quadrupole'])
+n_body_plug.run_n_body('b3lyp', n_body={'b3lyp': 3, 'bsse': 'ssfc'}, properties=['rotation'])
 
 
 

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -1224,12 +1224,15 @@ def harvest_cc_energy(db,method,n):
 def harvest_g09_scf_energy(db,method,n):
     body = n_body_dir(n)
     for job in db[method][n]['job_status']:
-        with open('{}/{}/{}/input.log'.format(method,body,job)) as outfile:
+        with open('{}/{}/{}/Test.FChk'.format(method,body,job)) as outfile:
             for line in outfile:
-                if 'SCF Done:' in line:
-                    (i,i,i,i, energy, i,i,i,i) = line.split()
-                    db[method][n]['scf_energy']['raw_data'].update({job:
-                                                                    [float(energy)]})
+                if 'SCF Energy' in line:
+                    (i, i, i, energy) = line.split()
+                    db[method][n]['scf_energy']['raw_data'].update({job:float(energy)})
+#                if 'SCF Done:' in line:
+#                    (i,i,i,i, energy, i,i,i,i) = line.split()
+#                    db[method][n]['scf_energy']['raw_data'].update({job:
+#                                                                    [float(energy)]})
 
 def harvest_g09_scf_dipole(db,method,n):
     body = n_body_dir(n)

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -1236,18 +1236,26 @@ def harvest_g09_scf_energy(db,method,n):
 
 def harvest_g09_scf_dipole(db,method,n):
     body = n_body_dir(n)
+    # FChk stores dipole moment in AU, convert to Debye
+    factor = psi4.constants.dipmom_au2debye
     for job in db[method][n]['job_status']:
         get_next = False
-        with open('{}/{}/{}/input.log'.format(method,body,job)) as outfile:
+        with open('{}/{}/{}/Test.FChk'.format(method,body,job)) as outfile:
             for line in outfile:
                 if get_next:
-                    # total dipole moment is discarded as n-body using magnitudes is meaningless
-                    (x,x_val,y,y_val,z,z_val,tot,tot_val) = line.split()
-                    db[method][n]['scf_dipole']['raw_data'].update({job:
-                                    [float(x_val),float(y_val),float(z_val)]})
+                    (x, y, z) = line.split()
+                    db[method][n]['scf_dipole']['raw_data'].update({job:[float(x)*factor,float(y)*factor,float(z)*factor]})
                     get_next = False
-                if 'Dipole moment' in line:
+                if 'Dipole Moment' in line:
                     get_next = True
+#                if get_next:
+#                    # total dipole moment is discarded as n-body using magnitudes is meaningless
+#                    (x,x_val,y,y_val,z,z_val,tot,tot_val) = line.split()
+#                    db[method][n]['scf_dipole']['raw_data'].update({job:
+#                                    [float(x_val),float(y_val),float(z_val)]})
+#                    get_next = False
+#                if 'Dipole moment' in line:
+#                    get_next = True
 
 
 def harvest_g09_quadrupole(db,method,n):

--- a/n_body_plug/n_body.py
+++ b/n_body_plug/n_body.py
@@ -1457,8 +1457,10 @@ def cook_data(db, method, n):
         # there is no polarizability so the list is NoneType. The above try fix
         # might work, but it would be better to figure out how to actually know
         # what data quantities are available in a smart way.
+#        correction = [0.0 for i in
+#                      range(len(cooked_data[n].itervalues().next()))]
         correction = [0.0 for i in
-                      range(len(cooked_data[n].itervalues().next()))]
+                      range(len(iter(cooked_data[n].values()).next()))]
         # Add up all contributions to current correction
         for key,val in cooked_data[n].items():
             correction = [x+y for x,y in zip(correction,val)]

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -367,9 +367,9 @@ def run_n_body(name, **kwargs):
 #                        n_body.harvest_g09(db,method,field)
 #                    else:
                     n_body.harvest_data(db,method,field)
-#            for field in db[method]['farm']:
-#                if isinstance(field, int):
-#                    n_body.cook_data(db,method,field)
+            for field in db[method]['farm']:
+                if isinstance(field, int):
+                    n_body.cook_data(db,method,field)
 #                    #if db['bsse'] == 'vmfc' and field > 1:
 #                    #    n_body.vmfc_cook(db, method, field)
 #                    #    n_body.mbcp_cook(db, method, field)

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -249,7 +249,8 @@ def run_n_body(name, **kwargs):
                             db[method][n]['job_status'].update({n_body.ghost_dir(indexes[k],ghost):
                                                                         'not_started'})
                             # Calculate molecular weight
-                            totmass = sum(((cluster.mass(i) if cluster.Z(i) else 0.) for i in range(cluster.natom())))
+                            totalmass = sum(mol2.mass(i) for i in range(mol2.natom()) if mol2.Z(i))
+                            totmass = sum(cluster.mass(i) for i in range(cluster.natom()) if cluster.Z(i))
                             db[method][n]['MW'].update({n_body.ghost_dir(indexes[k],ghost):totmass})
                             # Reactivate fragments for next round
                             cluster.set_active_fragments(list(ghost))
@@ -277,7 +278,7 @@ def run_n_body(name, **kwargs):
                             db[method][n]['total_num_jobs'] = len(list(itertools.combinations(range(0,n),n_real))) * len(clusters)
                             db[method][n]['job_status'].update({n_body.ghost_dir(indexes[k],ghost):
                                                                         'not_started'})
-                            totmass = sum(((cluster.mass(i) if cluster.Z(i) else 0.) for i in range(cluster.natom())))
+                            totmass = sum(cluster.mass(i) for i in range(cluster.natom()) if cluster.Z(i))
                             db[method][n]['MW'].update({n_body.ghost_dir(indexes[k],ghost):totmass})
                             # Reactivate fragments for next round
                             cluster.set_active_fragments(list(ghost))
@@ -294,7 +295,7 @@ def run_n_body(name, **kwargs):
                         # Update database job_status dict
                         db[method][n]['job_status'].update({n_body.cluster_dir(indexes[k]):
                                                                        'not_started'})
-                        totmass = sum(((cluster.mass(i) if cluster.Z(i) else 0.) for i in range(cluster.natom())))
+                        totmass = sum(cluster.mass(i) for i in range(cluster.natom()) if cluster.Z(i))
                         db[method][n]['MW'].update({n_body.cluster_dir(indexes[k]):totmass})
         # Check for zero jobs (happens occasionally due to cutoff)
         for method in db['methods']:

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -366,17 +366,17 @@ def run_n_body(name, **kwargs):
                 num_fin = db[method][field]['num_jobs_complete']
                 tot_num = db[method][field]['total_num_jobs']
                 print('{}/{} {}-body jobs finished'.format(num_fin,tot_num,field))
-#                if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
+                if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
 #                    if method in n_body.dft_methods:
 #                        n_body.harvest_g09(db,method,field)
-#                    if (method == 'b3lyp'):
-#                        print('Gotta harvest that b3lyp data')
-#                        n_body.harvest_g09(db,method,field)
-#                    else:
-                    n_body.harvest_data(db,method,field)
-            for field in db[method]['farm']:
-                if isinstance(field, int):
-                    n_body.cook_data(db,method,field)
+                    if (method == 'b3lyp'):
+                        print('Gotta harvest that b3lyp data')
+                        n_body.harvest_g09(db,method,field)
+                    else:
+                        n_body.harvest_data(db,method,field)
+#            for field in db[method]['farm']:
+#                if isinstance(field, int):
+#                    n_body.cook_data(db,method,field)
 #                    #if db['bsse'] == 'vmfc' and field > 1:
 #                    #    n_body.vmfc_cook(db, method, field)
 #                    #    n_body.mbcp_cook(db, method, field)


### PR DESCRIPTION
Title says it all: this pull request adds molecular weight of each fragment to the database and (more importantly) a variety of G09 reaping capabilities from the `Test.FChk` formatted checkpoint file: energies, dipoles, quadrupoles, rotation tensors, and rotations included. Polarizabilities will be implemented at a later date so that data cooking can begin. 