### PR TITLE
Added solute, timing, cook, and harvest to optional kwargs to run_n_body

### DIFF
--- a/n_body_plug/input.dat
+++ b/n_body_plug/input.dat
@@ -69,11 +69,17 @@ set {
 #n_body_plug.run_n_body('cc2', n_body={'cc2': 2, 'bsse': 'ssfc'}, properties=['quadrupole'])
 # gaussian integration is currently being fixed
 #n_body_plug.run_n_body('cam-b3lyp',  n_body={'cam-b3lyp': 3, 'bsse': 'ssfc'}, properties=['rotation'])
-#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc'}, properties=['rotation'])
+#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'num_threads': 2}, properties=['rotation'])
 
 # testing polarizabilities
-n_body_plug.run_n_body('cam-b3lyp',  n_body={'cam-b3lyp': 3, 'num_threads': 2}, properties=['polarizability'])
+#n_body_plug.run_n_body('cam-b3lyp',  n_body={'cam-b3lyp': 3, 'num_threads': 2}, properties=['polarizability'])
 
+# testing options for toggling solute rotations, timing, harvesting, and cooking
+#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'cook': False, 'num_threads': 2}, properties=['rotation'])
+#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'harvest': False, 'num_threads': 2}, properties=['rotation'])
+#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'solute': True, 'num_threads': 2}, properties=['rotation'])
+#n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'timing': True, 'num_threads': 2}, properties=['rotation'])
+n_body_plug.run_n_body('b3lyp',  n_body={'b3lyp': 3, 'bsse': 'ssfc', 'timing': True, 'solute': True, 'num_threads': 2}, properties=['rotation'])
 
 # generated input files should also have the following
 # (automatically added as of commit #2538754)

--- a/n_body_plug/pymodule.py
+++ b/n_body_plug/pymodule.py
@@ -90,6 +90,15 @@ def run_n_body(name, **kwargs):
         db['bsse'] = n_body_options['bsse']
     if 'pcm' in n_body_options:
         db['pcm'] = n_body_options['pcm']
+    if 'solute' in n_body_options:
+        db['solute'] = n_body_options['solute']
+    if 'timing' in n_body_options:
+        db['timing'] = n_body_options['timing']
+    if 'harvest' in n_body_options:
+        db['harvest'] = n_body_options['harvest']
+    if 'cook' in n_body_options:
+        db['cook'] = n_body_options['cook']
+
     # methods consistency check
     if 'methods' in n_body_options:
         for key,val in n_body_options['methods'].items():
@@ -379,29 +388,31 @@ def run_n_body(name, **kwargs):
                 tot_num = db[method][field]['total_num_jobs']
                 print('{}/{} {}-body jobs finished'.format(num_fin,tot_num,field))
                 if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
-#                    if method in n_body.dft_methods:
-#                        n_body.harvest_g09(db,method,field)
-#                    if (method == 'b3lyp'):
-                    if method in n_body.dft_methods:
-                        n_body.harvest_g09(db,method,field)
-                    else:
-                        n_body.harvest_data(db,method,field)
-            for field in db[method]['farm']:
-                if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
-#                if isinstance(field, int):
-                    n_body.cook_data(db,method,field)
-#                    #if db['bsse'] == 'vmfc' and field > 1:
-#                    #    n_body.vmfc_cook(db, method, field)
-#                    #    n_body.mbcp_cook(db, method, field)
-#                    if db['bsse'] == 'vmfc':
-#                        n_body.vmfc_cook(db, method, field)
-#                        if field > 1:
-#                            n_body.mbcp_cook(db, method, field)
-#                    elif db['bsse'] == 'mbcp' and field > 1:
-#                        n_body.mbcp_cook(db,method,field)
-#                    # Future location of an if check for mass adjust or not
-#                    if 'rotation' in db[method]['results']:
-#                        n_body.mass_adjust_rotations(db,method,field)
+                    if db['harvest']:
+                        if method in n_body.dft_methods:
+                            n_body.harvest_g09(db,method,field)
+                        else:
+                            n_body.harvest_data(db,method,field)
+            if not db['harvest']:
+                print("Data harvesting has been disabled.")
+            elif not db['cook']:
+                print("Data cooking has been disabled.")
+            else:
+                for field in db[method]['farm']:
+                    if (db[method][field]['num_jobs_complete'] == db[method][field]['total_num_jobs']):
+                        n_body.cook_data(db,method,field)
+#                       #if db['bsse'] == 'vmfc' and field > 1:
+#                       #    n_body.vmfc_cook(db, method, field)
+#                       #    n_body.mbcp_cook(db, method, field)
+#                       if db['bsse'] == 'vmfc':
+#                           n_body.vmfc_cook(db, method, field)
+#                           if field > 1:
+#                               n_body.mbcp_cook(db, method, field)
+#                       elif db['bsse'] == 'mbcp' and field > 1:
+#                           n_body.mbcp_cook(db,method,field)
+#                       # Future location of an if check for mass adjust or not
+#                       if 'rotation' in db[method]['results']:
+#                           n_body.mass_adjust_rotations(db,method,field)
 
     db.close()
     db = shelve.open('database',writeback=True)


### PR DESCRIPTION
These options can be set in the `nbody={}` kwargs to `n_body_plug.run_n_body`.